### PR TITLE
Fix 400 Bad Request

### DIFF
--- a/lib/createBadgeUrl.js
+++ b/lib/createBadgeUrl.js
@@ -7,5 +7,5 @@ module.exports = opts => report => {
     report.overallPercent >= opts.thresholds.good ? 'yellow' : 'red'
   )
 
-  return `https://img.shields.io/badge/coverage-${report.overallPercent}%-${color}.${opts.badgeFormat}?style=${opts.shieldStyle}`
+  return `https://img.shields.io/badge/coverage-${report.overallPercent}%25-${color}.${opts.badgeFormat}?style=${opts.shieldStyle}`
 }


### PR DESCRIPTION
This pull request url encodes the % in `createBadgeUrl.js`.

Seems that percent signs now need to be encoded when talking to http://shields.io/. Something must have changed on their end that caused this change, since this change didn't used to be required for me.

In the project I noticed this, coverage-badger uses https://img.shields.io/badge/coverage-75%-yellow.svg?style=undefined which returns a 400 Bad Request. https://img.shields.io/badge/coverage-75%25-yellow.svg?style=undefined should instead be used.
